### PR TITLE
Progress towards returning the terminal to sanity on exit

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -103,6 +103,9 @@ void render() {
 }
 
 int main() {
+    // save initial terminal state first and foremost
+    saveTerminal();
+
     // precalc
     for (int i = 0; i < 256; i++)
         characterLengths[i] = sweepCharLength(i);

--- a/main.hpp
+++ b/main.hpp
@@ -45,6 +45,7 @@ void render();
 void initSDLAudio();
 
 // Terminal
+void saveTerminal();
 void createTerminal();
 void runTerminal();
 

--- a/terminal.cpp
+++ b/terminal.cpp
@@ -36,14 +36,17 @@ void sigchldHandler(int signum) {
     }
 }
 
+void saveTerminal() {
+    // Fetch original terminal settings
+    tcgetattr(STDIN_FILENO, &ogterm);
+}
+
 void restoreTerminal() { 
+    // Restore original terminal settings
     tcsetattr(STDIN_FILENO, TCSANOW, &ogterm);
 }
 
 void createTerminal() {
-    // Fetch original terminal settings
-    tcgetattr(STDIN_FILENO, &ogterm);
-
     // Set non-canonical mode for parent process stdin
     termios termios_p {};
     termios_p.c_lflag = termios_p.c_lflag & ~(ICANON);

--- a/terminal.cpp
+++ b/terminal.cpp
@@ -42,7 +42,8 @@ void saveTerminal() {
 }
 
 void restoreTerminal() { 
-    // Restore original terminal settings
+    // Restore original terminal settings. Also manually set ONLCR.
+    ogterm.c_oflag |= ONLCR;
     tcsetattr(STDIN_FILENO, TCSANOW, &ogterm);
 }
 

--- a/terminal.cpp
+++ b/terminal.cpp
@@ -18,19 +18,23 @@ static int masterfd = 0;
 static int childpid = 0;
 static termios ogterm {};
 
+void restoreTerminal();
+
 void sigchldHandler(int signum) {
     if (signum == SIGCHLD) {
         int result = 0;
         waitpid(childpid, &result, WNOHANG);
 
         if (WIFEXITED(result)) {
-            std::cout << "Error: SIGCHLD shell process exited" << std::endl;
+            restoreTerminal();
+            std::cout << "\r" << std::flush << "Error: SIGCHLD shell process exited" << std::endl;
 
             // Reset canonical mode for parent process stdin
             /*termios termios_p {};
             termios_p.c_lflag = termios_p.c_lflag & ICANON;
             tcsetattr(0, TCSANOW, &termios_p);*/
-            system("reset");
+            // system("reset");
+            restoreTerminal();
             exit(1);
         }
     }

--- a/terminal.cpp
+++ b/terminal.cpp
@@ -34,7 +34,6 @@ void sigchldHandler(int signum) {
             termios_p.c_lflag = termios_p.c_lflag & ICANON;
             tcsetattr(0, TCSANOW, &termios_p);*/
             // system("reset");
-            restoreTerminal();
             exit(1);
         }
     }


### PR DESCRIPTION
This code tries to save the initial terminal state and restore it upon exit (using `atexit()` handlers) although it doesn't seem to restore implicit carriage return processing (programs running thereafter look "cascaded" as their newlines will begin in the column right after their old lines ended, like this): 

![image](https://github.com/arf20/oscilloscope-terminal/assets/480709/cffe2862-8210-4d0b-867a-105616b5a655)

However, it doesn't seem to always break, and sometimes leaves the terminal in a sane state at the end. Consider it a work-in progress. 